### PR TITLE
Fix incompatibility of the TranslatorPass compiler pass with Symfony 3.3+

### DIFF
--- a/DependencyInjection/Compiler/TranslatorPass.php
+++ b/DependencyInjection/Compiler/TranslatorPass.php
@@ -37,12 +37,13 @@ class TranslatorPass implements CompilerPassInterface
         $xlfTranslations = $this->getTranslationFiles($container);
 
         if (count($xlfTranslations) > 0) {
+            $optionsArgumentIndex = count($translator->getArguments()) - 1;
             $options = array_merge_recursive(
-                $translator->getArgument(3),
+                $translator->getArgument($optionsArgumentIndex),
                 array('resource_files' => $xlfTranslations)
             );
 
-            $translator->replaceArgument(3, $options);
+            $translator->replaceArgument($optionsArgumentIndex, $options);
         }
     }
 

--- a/Tests/DependencyInjection/Compiler/TranslatorPassTest.php
+++ b/Tests/DependencyInjection/Compiler/TranslatorPassTest.php
@@ -72,6 +72,10 @@ class TranslatorPassTest extends \PHPUnit_Framework_TestCase
             ->willReturn($translator);
 
         $translator->expects($this->once())
+            ->method('getArguments')
+            ->willReturn([null, null, [], []]);
+
+        $translator->expects($this->once())
             ->method('getArgument')
             ->with(3)
             ->willReturn(array());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR fix issue #13. A quick recap of the problem: since Symfony 3.3 the `TranslatorPass` is not compatible anymore due to a new argument added to the constructor of the service class it acts on and an exception is thrown.